### PR TITLE
Only propagate CMAKE_BUILD_TYPE for single configuration generators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,6 @@ macro(build_libyaml)
     TIMEOUT 60
     CMAKE_ARGS
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/libyaml_install
-
       ${extra_cmake_args}
   )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,9 @@ find_package(ament_cmake REQUIRED)
 
 macro(build_libyaml)
   set(extra_cmake_args)
-  if(DEFINED CMAKE_BUILD_TYPE)
+
+  get_property(multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+  if(NOT multi_config AND DEFINED CMAKE_BUILD_TYPE)
     list(APPEND extra_cmake_args -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
   endif()
 
@@ -51,6 +53,7 @@ macro(build_libyaml)
     TIMEOUT 60
     CMAKE_ARGS
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/libyaml_install
+
       ${extra_cmake_args}
   )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.9)
 
 project(libyaml_vendor)
 


### PR DESCRIPTION
This fixes a CMake warning that started happening in the windows Nightly on `libyaml_vendor`.

Build with warning:

https://ci.ros2.org/view/packaging/job/packaging_windows/1683/

```
[202.860s] CUSTOMBUILD : CMake warning :  [C:\ci\ws\build\libyaml_vendor\libyaml-10c9078.vcxproj]
[202.860s]     Manually-specified variables were not used by the project:
[202.860s]   
[202.860s]       CMAKE_BUILD_TYPE
[202.860s]   
[202.860s]   
[202.860s]   -- Build files have been written to: C:/ci/ws/build/libyaml_vendor/libyaml-10c9078-prefix/src/libyaml-10c9078-build
```

We don't need to pass anything in if using a multi config generator, because [those propagate `--config` to external projects already](https://gitlab.kitware.com/cmake/cmake/issues/17645#note_367584).

I don't know why this warning started showing up on `libyaml_vendor`. I also don't know why this warning [doesn't appear on other vendor packages with the same logic](https://github.com/ros2/poco_vendor/blob/3f23e18f8d71e979e03395d860bc3053d3162ae6/CMakeLists.txt#L19-L21).

Side note, I'm pleasantly surprised [colcon handles passing `--config` on windows when someone gives CMAKE_BUILD_TYPE](https://github.com/colcon/colcon-cmake/blob/fff16c206886a63517c848792d3fb68601c4a8cd/colcon_cmake/task/cmake/build.py#L337) :tada: :magic: