### PR TITLE
add missing export of yaml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ endmacro()
 build_libyaml()
 
 ament_export_libraries(yaml)
+ament_export_dependencies(yaml)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)


### PR DESCRIPTION
Required for ros2/rcl#630.

Related to ros2/ros2#904.