### PR TITLE
Foxy QD point to Foxy benchmark tests

### DIFF
--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -94,7 +94,7 @@ Lastest code coverage can be found [here](https://ci.ros2.org/job/ci_linux_cover
 
 ### Performance [4.iv]
 
-The `libyaml` package is benchmarked and the most recent test results can be found [here](http://build.ros2.org/view/Rci/job/Rci__benchmark_ubuntu_focal_amd64/BenchmarkTable/).
+The `libyaml` package is benchmarked and the most recent test results can be found [here](http://build.ros2.org/view/Fci/job/Fci__benchmark_ubuntu_focal_amd64/BenchmarkTable/).
 
 ### Linters and Static Analysis [4.v]
 


### PR DESCRIPTION
I believe the results for `libyaml` will only be visible from the next build.

CC @ahcorde 