### PR TITLE
Always preserve source permissions in vendor packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,7 @@ macro(build_libyaml)
       ${CMAKE_CURRENT_BINARY_DIR}/libyaml_install/
     DESTINATION
       ${CMAKE_INSTALL_PREFIX}
+    USE_SOURCE_PERMISSIONS
     PATTERN config.h EXCLUDE
   )
 


### PR DESCRIPTION
In vendor packages where we're installing an executable, we use USE_SOURCE_PERMISSIONS to make sure that the executable permissions on the binaries are maintained when the external project's staging directory is recursively installed to the final installation directory.

In most of our vendor packages, we aren't using that flag where we don't expect an executable binary to be installed. However, for reasons I won't go into here, some systems use executable permissions on shared object libraries as well. The linker seems to handle this on our behalf, but we're losing the permissions during the recursive copy operation if we don't use this flag.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13642)](http://ci.ros2.org/job/ci_linux/13642/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8522)](http://ci.ros2.org/job/ci_linux-aarch64/8522/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11357)](http://ci.ros2.org/job/ci_osx/11357/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13705)](http://ci.ros2.org/job/ci_windows/13705/)