### PR TITLE
check if libyaml is already present before building it (take 2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,16 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wconversion -Wno-sign-conversion -Wpedantic -Wnon-virtual-dtor -Woverloaded-virtual)
 endif()
 
+option(FORCE_BUILD_VENDOR_PKG
+  "Build libyaml from source, even if system-installed package is available"
+  OFF)
+
 find_package(ament_cmake REQUIRED)
+list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
+
+if(NOT FORCE_BUILD_VENDOR_PKG)
+  find_package(yaml QUIET)
+endif()
 
 macro(build_libyaml)
   set(extra_cmake_args)
@@ -99,15 +108,35 @@ macro(build_libyaml)
   set(yaml_LIBRARIES yaml)
 endmacro()
 
-build_libyaml()
-set(extra_test_dependencies libyaml-0.2.5)
+# Skip building yaml if the expected version is already present in the system
+if(yaml_FOUND)
+  if("${yaml_VERSION}" VERSION_EQUAL 0.2.5)
+    set(_SKIP_YAML_BUILD 1)
+  else()
+    message(WARNING
+      "A wrong version of libyaml is already present in the system: ${yaml_VERSION}."
+      "It will be ignored and the 0.2.5 version will be built.")
+  endif()
+endif()
 
-ament_export_libraries(yaml)
+if(NOT _SKIP_YAML_BUILD)
+  build_libyaml()
+  set(extra_test_dependencies libyaml-0.2.5)
+endif()
+
 ament_export_dependencies(yaml)
 
 if(BUILD_TESTING)
+  # We need to install a Findyaml.cmake file that does not respect
+  # ament_cmake_lint_cmake's convention/filename and package/stdargs rules
+  # See https://github.com/ros2/libyaml_vendor/pull/45#issuecomment-1087559657
+  list(APPEND AMENT_LINT_AUTO_EXCLUDE
+    ament_cmake_lint_cmake
+  )
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+  find_package(ament_cmake_lint_cmake REQUIRED)
+  ament_lint_cmake("--filter=-convention/filename,-package/stdargs")
 
   find_package(ament_cmake_gtest REQUIRED)
   find_package(rcpputils REQUIRED)
@@ -148,5 +177,7 @@ if(BUILD_TESTING)
     endif()
   endif()
 endif()
+
+install(DIRECTORY cmake DESTINATION share/${PROJECT_NAME})
 
 ament_package(CONFIG_EXTRAS libyaml_vendor-extras.cmake)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # libyaml_vendor
-CMake wrapper downloading and building libyaml.
+CMake wrapper to provide libyaml.
 
-This package CMake script check if a `libyaml` that has exactly the version required by ROS2 is available in the system. 
+The CMake script in this package checks if a `libyaml` that has exactly the version required by ROS 2 is available in the system.
 
-If such `libyaml` is available in the system, it only installs a [`Findyaml.cmake`](cmake/Modules/Findyaml.cmake) CMake find module, 
+If such `libyaml` is available in the system, it only installs a [`Findyaml.cmake`](cmake/Modules/Findyaml.cmake) CMake find module,
 to ensure that the library can be always found via:
 ~~~cmake
 find_package(yaml REQUIRED)
@@ -14,10 +14,10 @@ target_link_libraries(<target> PRIVATE yaml)
 ~~~
 even if no CMake config file for `yaml` is installed in the system.
 
-If a `libyaml` that has exactly the version required by ROS2 is not available in the system, then it downloads and installs the 
+If a `libyaml` that has exactly the version required by ROS 2 is not available in the system, then it downloads and installs
 `libyaml` as part of this package thanks to [CMake's ExternalProject module](https://cmake.org/cmake/help/latest/module/ExternalProject.html).
 
-The `FORCE_BUILD_VENDOR_PKG` CMake option (that by default is `OFF`) is provided to permit to force the building of `libyaml`, regardless
+The `FORCE_BUILD_VENDOR_PKG` CMake option (that by default is `OFF`) is provided to allow forcing a `libyaml` build, regardless
 of what can be found in the system.
 
 ## Quality Declaration files

--- a/README.md
+++ b/README.md
@@ -1,5 +1,24 @@
 # libyaml_vendor
-CMake wrapper downloading and building libyaml
+CMake wrapper downloading and building libyaml.
+
+This package CMake script check if a `libyaml` that has exactly the version required by ROS2 is available in the system. 
+
+If such `libyaml` is available in the system, it only installs a [`Findyaml.cmake`](cmake/Modules/Findyaml.cmake) CMake find module, 
+to ensure that the library can be always found via:
+~~~cmake
+find_package(yaml REQUIRED)
+~~~
+and linked via:
+~~~cmake
+target_link_libraries(<target> PRIVATE yaml)
+~~~
+even if no CMake config file for `yaml` is installed in the system.
+
+If a `libyaml` that has exactly the version required by ROS2 is not available in the system, then it downloads and installs the 
+`libyaml` as part of this package thanks to [CMake's ExternalProject module](https://cmake.org/cmake/help/latest/module/ExternalProject.html).
+
+The `FORCE_BUILD_VENDOR_PKG` CMake option (that by default is `OFF`) is provided to permit to force the building of `libyaml`, regardless
+of what can be found in the system.
 
 ## Quality Declaration files
 

--- a/cmake/Modules/Findyaml.cmake
+++ b/cmake/Modules/Findyaml.cmake
@@ -1,0 +1,36 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(FindPackageHandleStandardArgs)
+find_package(yaml CONFIG QUIET)
+if(yaml_FOUND)
+  find_package_handle_standard_args(yaml FOUND_VAR yaml_FOUND CONFIG_MODE)
+else()
+  # Otherwise, rely on pkg-config
+  find_package(PkgConfig QUIET)
+
+  if(PKG_CONFIG_FOUND)
+    pkg_check_modules(YAML_PKG_CONFIG IMPORTED_TARGET yaml-0.1)
+    find_package_handle_standard_args(yaml DEFAULT_MSG YAML_PKG_CONFIG_FOUND)
+
+    if(yaml_FOUND)
+      if(NOT TARGET yaml)
+        add_library(yaml INTERFACE IMPORTED)
+        set_property(TARGET yaml PROPERTY INTERFACE_LINK_LIBRARIES PkgConfig::YAML_PKG_CONFIG)
+      endif()
+      set(yaml_LIBRARIES yaml)
+      set(yaml_VERSION ${YAML_PKG_CONFIG_VERSION})
+    endif()
+  endif()
+endif()

--- a/libyaml_vendor-extras.cmake
+++ b/libyaml_vendor-extras.cmake
@@ -14,4 +14,6 @@
 
 # copied from libyaml_vendor/libyaml_vendor-extras.cmake
 
+list(INSERT CMAKE_MODULE_PATH 0 "${libyaml_vendor_DIR}/Modules")
+
 list(APPEND libyaml_vendor_TARGETS yaml)

--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,9 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>git</buildtool_depend>
+  <buildtool_depend>pkg-config</buildtool_depend>
+
+  <buildtool_export_depend>pkg-config</buildtool_export_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -23,11 +23,16 @@
 
   <buildtool_export_depend>pkg-config</buildtool_export_depend>
 
+  <build_depend>libyaml</build_depend>
+
+  <exec_depend>libyaml</exec_depend>
+
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>performance_test_fixture</test_depend>
   <test_depend>rcpputils</test_depend>
+  <test_depend>rcutils</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
This PR builds on https://github.com/ros2/libyaml_vendor/pull/41, handling the case in which yaml is installed in the system using only the autotools build system, in which case no yaml cmake config files are installed (upstream issue: https://github.com/yaml/libyaml/issues/222).