### PR TITLE
Install headers to include/${PROJECT_NAME}

### DIFF
--- a/0001-Install-yaml.h-to-INSTALL_INCLUDE_DIR.patch
+++ b/0001-Install-yaml.h-to-INSTALL_INCLUDE_DIR.patch
@@ -1,0 +1,26 @@
+From bfcbb19c954fa20a68708e707e76c725058e001f Mon Sep 17 00:00:00 2001
+From: Shane Loretz <sloretz@osrfoundation.org>
+Date: Tue, 1 Mar 2022 16:54:10 -0800
+Subject: [PATCH] Install yaml.h to INSTALL_INCLUDE_DIR
+
+Signed-off-by: Shane Loretz <sloretz@osrfoundation.org>
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4f81148..80b12cb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -84,7 +84,7 @@ target_include_directories(yaml PUBLIC
+ install(
+   FILES
+     include/yaml.h
+-  DESTINATION include COMPONENT Development
++  DESTINATION ${INSTALL_INCLUDE_DIR} COMPONENT Development
+   )
+ 
+ install(
+-- 
+2.25.1
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,12 +61,20 @@ macro(build_libyaml)
   endif()
   include(ExternalProject)
   externalproject_add(libyaml-0.2.5
-    URL https://github.com/yaml/libyaml/archive/refs/tags/0.2.5.zip
-    URL_MD5 2464078985a73f9d298689d36061143f
-    TIMEOUT 60
+    GIT_REPOSITORY https://github.com/yaml/libyaml.git
+    GIT_TAG 2c891fc7a770e8ba2fec34fc6b545c672beb37e6  # 0.2.5
+    GIT_CONFIG advice.detachedHead=false
+    # Suppress git update due to https://gitlab.kitware.com/cmake/cmake/-/issues/16419
+    # See https://github.com/ament/uncrustify_vendor/pull/22 for details
+    UPDATE_COMMAND ""
+    TIMEOUT 600
     CMAKE_ARGS
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/libyaml_install
+      -DINSTALL_INCLUDE_DIR:STRING=include/${PROJECT_NAME}
       ${extra_cmake_args}
+    PATCH_COMMAND
+      ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git apply -p1 --ignore-space-change --whitespace=nowarn
+        ${CMAKE_CURRENT_SOURCE_DIR}/0001-Install-yaml.h-to-INSTALL_INCLUDE_DIR.patch
   )
 
   # The external project will install to the build folder, but we'll install that on make install.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ macro(build_libyaml)
     PATTERN config.h EXCLUDE
   )
 
-  set(yaml_INCLUDE_DIRS ${CMAKE_CURRENT_BINARY_DIR}/libyaml_install/include)
+  set(yaml_INCLUDE_DIRS ${CMAKE_CURRENT_BINARY_DIR}/libyaml_install/include/${PROJECT_NAME})
   set(yaml_LIBRARY_DIRS ${CMAKE_CURRENT_BINARY_DIR}/libyaml_install/lib)
   set(yaml_LIBRARIES yaml)
 endmacro()


### PR DESCRIPTION
The patch is taken from this PR https://github.com/yaml/libyaml/pull/244

This is in support of ros2/ros2#1150

The `externalproject_add(` changes are from [`ignition_math6_vendor`](https://github.com/ignition-release/ignition_math6_vendor/blob/c15daef12f8cd1d131d161395baa6f3ed4e25f72/CMakeLists.txt#L53-L67).