### PR TITLE
Add a buildtool dependency on git.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -18,6 +18,7 @@
   <author>Mikael Arguedas</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>git</buildtool_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
Git is required to fetch this vendor package.
Since our usual development setup installs git anyway this dependency is
hard to spot unless you're doing arcane things with containers.