### PR TITLE
Update libyaml_vendor to C++17.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,10 @@ cmake_minimum_required(VERSION 3.9)
 
 project(libyaml_vendor)
 
-# Default to C++14
+# Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   # About -Wno-sign-conversion: With Clang, -Wconversion implies -Wsign-conversion. There are a number of


### PR DESCRIPTION
The two reasons to do this are:

1. So that we can compile libyaml_vendor with the clang static analyzer. As of clang++-14 (what is in Ubuntu 22.04), the default still seems to be C++14, so we need to specify C++17 so that new things in the rclcpp headers work properly.
2. So we can build with a newer version of gtest which requires this.

Further, due to reasons I don't fully understand, I needed to set CMAKE_CXX_STANDARD_REQUIRED in order for clang to really use that version. So set this as well.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>