### PR TITLE
Only set CRT_SECURE_NO_WARNINGS if it hasn't already been set.

### DIFF
--- a/test/benchmark/benchmark_reader.cpp
+++ b/test/benchmark/benchmark_reader.cpp
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 #ifdef _WIN32
+#ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
+#endif
 #endif
 
 #include <yaml.h>

--- a/test/test_reader.cpp
+++ b/test/test_reader.cpp
@@ -13,9 +13,10 @@
 // limitations under the License.
 
 #ifdef _WIN32
+#ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
 #endif
-
+#endif
 
 #include <gtest/gtest.h>
 #include <yaml.h>


### PR DESCRIPTION
It seems when building with some conda packages, it may already be set.  This just removes a warning.

@ahcorde FYI